### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-devops-backup.yml
+++ b/.github/workflows/azure-devops-backup.yml
@@ -1,6 +1,9 @@
 # $version: v4-1766267229
 name: Backup Main Branch to Azure DevOps
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/azure-devops-backup.yml
+++ b/.github/workflows/azure-devops-backup.yml
@@ -1,4 +1,4 @@
-# $version: v4-1766267229
+# $version: v5-1771213470
 name: Backup Main Branch to Azure DevOps
 
 permissions:


### PR DESCRIPTION
Potential fix for [https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/1](https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/1)

In general, the fix is to explicitly declare a restrictive `permissions` block so the `GITHUB_TOKEN` has only the minimal scopes required. This workflow only needs to read repository contents to allow `actions/checkout` to operate; it pushes to Azure DevOps using an SSH key, not via `GITHUB_TOKEN`, so it does not need write permissions on GitHub.

The best fix without changing functionality is to add a `permissions` block at the workflow root (top-level, alongside `name` and `on`) specifying `contents: read`. This will apply to all jobs in the workflow (there is only one job, `backup-main-to-azure-devops`) and ensure that `GITHUB_TOKEN` cannot write to repository contents or other resources. No additional imports or job-level changes are needed; we only modify `.github/workflows/azure-devops-backup.yml` to add the block near the top of the file.

Specifically, in `.github/workflows/azure-devops-backup.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Backup Main Branch to Azure DevOps` line and the `on:` block. This documents the required permissions and prevents the workflow from inheriting broader defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
