### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -10,6 +10,8 @@ jobs:
     if: ${{ github.event.repository.fork }}
     name: Sync latest commits from upstream
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/2](https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/2)

In general, to fix this issue you should explicitly define a `permissions` block that grants the minimal set of scopes the workflow actually needs. This can be done at the workflow root (applies to all jobs) or per job (overrides/defines permissions for that specific job). For this workflow, the sync job needs to read and push commits to the repository, which requires `contents: write`; no other special scopes (like `issues` or `pull-requests`) are apparent from the snippet.

The best fix with no functional change is to add a `permissions` block under the `sync` job specifying `contents: write`. This constrains the `GITHUB_TOKEN` to repository contents operations only, while still allowing the Fork-Sync-With-Upstream action to push changes. Concretely, in `.github/workflows/upstream-sync.yml`, you should modify the `sync` job definition (around lines 8–13) to insert:

```yaml
    permissions:
      contents: write
```

between `runs-on: ubuntu-latest` and `steps:`. No additional imports or methods are needed because this is purely a workflow configuration change. If in the future you discover the job only needs read access (no pushes), you can tighten this further to `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
