### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ github.repository != 'Rexezuge-CloudflareWorkers/AWS-AccessBridge' }}
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/3](https://github.com/Rexezuge-CloudflareWorkers/AWS-AccessBridge/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions` block for the workflow or the specific job, granting only the minimal required scopes. Since this workflow only checks out code and runs local tools, the minimal safe starting point is `contents: read` at the workflow or job level, as suggested by CodeQL. This ensures the `GITHUB_TOKEN` cannot be used to write to the repository or perform other unnecessary operations, even if repo/org defaults are broader or later change.

The best, non-invasive fix here is to add a `permissions` block at the job level under `jobs.deploy`, because that directly addresses the highlighted job and won’t affect other workflows. Concretely, in `.github/workflows/deploy-cloudflare-worker.yml`, under `jobs: deploy:` (around line 10), after the `name: Deploy to Cloudflare` (or just before `runs-on:`), insert:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed because this is a YAML workflow configuration change only. Functionality of the workflow is unchanged; it still checks out the repository, installs dependencies, initializes secrets, applies migrations, and deploys, but with a restricted `GITHUB_TOKEN` scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
