### PR TITLE
Refactor request audit and authentication into middleware

### DIFF
--- a/src/endpoints/IActivityAPIRoute.ts
+++ b/src/endpoints/IActivityAPIRoute.ts
@@ -1,15 +1,13 @@
 import { OpenAPIRoute } from 'chanfana';
 import { Context } from 'hono';
 import type { StatusCode } from 'hono/utils/http-status';
-import { EmailValidationUtil, TokenAuthUtil, BaseUrlUtil } from '@/utils';
+import { BaseUrlUtil } from '@/utils';
 import { DefaultInternalServerError, InternalServerError, IServiceError } from '@/error';
-import { D1_SESSION_CONSTRAINT_FIRST_UNCONSTRAINED, DEMO_USER_EMAIL, DEFAULT_DEMO_MODE } from '@/constants';
+import { D1_SESSION_CONSTRAINT_FIRST_UNCONSTRAINED, DEFAULT_DEMO_MODE } from '@/constants';
 
 abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IResponse, TEnv extends IEnv> extends OpenAPIRoute {
   async handle(c: ActivityContext<TEnv>) {
     try {
-      const userEmail: string = await this.authenticateUserIdentity(c);
-      c.set('AuthenticatedUserEmailAddress', userEmail);
       let body: unknown = {};
       try {
         body = await c.req.json();
@@ -68,18 +66,6 @@ abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IR
   protected isDemoMode(c: ActivityContext<TEnv>): boolean {
     const env: TEnv = c.env as TEnv;
     return (env.DEMO_MODE || DEFAULT_DEMO_MODE) === 'true';
-  }
-
-  private async authenticateUserIdentity(c: ActivityContext<TEnv>): Promise<string> {
-    if (this.isDemoMode(c)) {
-      return DEMO_USER_EMAIL;
-    }
-    const authHeader: string | undefined = c.req.header('Authorization');
-    if (authHeader && authHeader.startsWith('Bearer ')) {
-      const token: string = authHeader.substring(7);
-      return await TokenAuthUtil.authenticateWithPAT(token, c.env.AccessBridgeDB);
-    }
-    return await EmailValidationUtil.getAuthenticatedUserEmail(c.req.raw, c.env.TEAM_DOMAIN, c.env.POLICY_AUD);
   }
 }
 

--- a/src/endpoints/IActivityAPIRoute.ts
+++ b/src/endpoints/IActivityAPIRoute.ts
@@ -4,16 +4,11 @@ import type { StatusCode } from 'hono/utils/http-status';
 import { EmailValidationUtil, TokenAuthUtil, BaseUrlUtil } from '@/utils';
 import { DefaultInternalServerError, InternalServerError, IServiceError } from '@/error';
 import { D1_SESSION_CONSTRAINT_FIRST_UNCONSTRAINED, DEMO_USER_EMAIL, DEFAULT_DEMO_MODE } from '@/constants';
-import { AUDIT_ACTIONS } from '@/constants/AuditActions';
-import { AuditLogDAO } from '@/dao/AuditLogDAO';
 
 abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IResponse, TEnv extends IEnv> extends OpenAPIRoute {
   async handle(c: ActivityContext<TEnv>) {
-    let userEmail: string = 'unknown';
-    let statusCode: number = 200;
-
     try {
-      userEmail = await this.authenticateUserIdentity(c);
+      const userEmail: string = await this.authenticateUserIdentity(c);
       c.set('AuthenticatedUserEmailAddress', userEmail);
       let body: unknown = {};
       try {
@@ -26,7 +21,7 @@ abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IR
       const response: TResponse | ExtendedResponse<TResponse> = await this.handleRequest(request, env, c);
       if (response && typeof response === 'object' && ('body' in response || 'statusCode' in response || 'headers' in response)) {
         const extendedResponse: ExtendedResponse<TResponse> = response as ExtendedResponse<TResponse>;
-        statusCode = extendedResponse.statusCode || 200;
+        const statusCode: number = extendedResponse.statusCode || 200;
         const headers: Record<string, string> = extendedResponse.headers || {};
         Object.entries(headers).forEach(([key, value]) => {
           c.header(key, value);
@@ -40,14 +35,12 @@ abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IR
       return c.json(response);
     } catch (error: unknown) {
       if (error instanceof IServiceError && !(error instanceof InternalServerError)) {
-        statusCode = error.getErrorCode();
         console.warn(`Responding with ${error.getErrorType()}Error: `, error.stack);
         return c.json({ Exception: { Type: error.getErrorType(), Message: error.getErrorMessage() } }, error.getErrorCode());
       }
       if (!(error instanceof IServiceError) || error instanceof InternalServerError) {
         console.error('Caught service error during execution: ', error);
       }
-      statusCode = DefaultInternalServerError.getErrorCode();
       console.warn('Responding with DefaultInternalServerError: ', DefaultInternalServerError);
       return c.json(
         {
@@ -55,22 +48,6 @@ abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IR
         },
         DefaultInternalServerError.getErrorCode(),
       );
-    } finally {
-      try {
-        const method: string = c.req.method;
-        const url: URL = new URL(c.req.url);
-        const path: string = url.pathname;
-        const action: string = AUDIT_ACTIONS[`${method}:${path}`] || `${method}:${path}`;
-        const ipAddress: string | undefined = c.req.header('CF-Connecting-IP');
-        const userAgentHeader: string | undefined = c.req.header('User-Agent');
-
-        const auditLogDAO: AuditLogDAO = new AuditLogDAO(c.env.AccessBridgeDB);
-        c.executionCtx.waitUntil(
-          auditLogDAO.create(userEmail, action, method, path, statusCode, undefined, undefined, ipAddress, userAgentHeader),
-        );
-      } catch {
-        console.warn('Failed to write audit log');
-      }
     }
   }
 
@@ -89,7 +66,8 @@ abstract class IActivityAPIRoute<TRequest extends IRequest, TResponse extends IR
   }
 
   protected isDemoMode(c: ActivityContext<TEnv>): boolean {
-    return (c.env.DEMO_MODE || DEFAULT_DEMO_MODE) === 'true';
+    const env: TEnv = c.env as TEnv;
+    return (env.DEMO_MODE || DEFAULT_DEMO_MODE) === 'true';
   }
 
   private async authenticateUserIdentity(c: ActivityContext<TEnv>): Promise<string> {

--- a/src/middleware/MiddlewareHandlers.ts
+++ b/src/middleware/MiddlewareHandlers.ts
@@ -1,10 +1,20 @@
 import { AUDIT_ACTIONS } from '@/constants/AuditActions';
-import { INTERNAL_HEADER_PREFIX, SELF_WORKER_BASE_HOSTNAME } from '@/constants';
+import { DEMO_USER_EMAIL, DEFAULT_DEMO_MODE, INTERNAL_HEADER_PREFIX, SELF_WORKER_BASE_HOSTNAME } from '@/constants';
 import { AuditLogDAO } from '@/dao/AuditLogDAO';
 import { Context, Next } from 'hono';
 import { HMACHandler } from './HMACHandler';
 import { IServiceError } from '@/error';
-import { ErrorTranslationUtil } from '@/utils';
+import { EmailValidationUtil } from '@/utils/EmailValidationUtil';
+import { ErrorTranslationUtil } from '@/utils/ErrorTranslationUtil';
+import { TokenAuthUtil } from '@/utils/TokenAuthUtil';
+
+type RequestContext = Context<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>;
+type AuthenticatedEnv = Env & {
+  DEMO_MODE?: string | undefined;
+  TEAM_DOMAIN?: string | undefined;
+  POLICY_AUD?: string | undefined;
+  AccessBridgeDB: D1DatabaseSession;
+};
 
 class MiddlewareHandlers {
   public static hmacValidation() {
@@ -20,10 +30,7 @@ class MiddlewareHandlers {
   }
 
   public static activityAudit() {
-    return async (
-      c: Context<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>,
-      next: Next,
-    ): Promise<void> => {
+    return async (c: RequestContext, next: Next): Promise<void> => {
       let statusCode: number = 200;
 
       try {
@@ -57,6 +64,21 @@ class MiddlewareHandlers {
     };
   }
 
+  public static authentication() {
+    return async (c: RequestContext, next: Next): Promise<Response | void> => {
+      try {
+        const userEmail: string = await this.authenticateUserIdentity(c);
+        c.set('AuthenticatedUserEmailAddress', userEmail);
+        await next();
+      } catch (error: unknown) {
+        if (error instanceof IServiceError) {
+          return c.json({ Exception: { Type: error.getErrorType(), Message: error.getErrorMessage() } }, error.getErrorCode());
+        }
+        throw error;
+      }
+    };
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private static withErrorTranslation<T extends any[], R>(fn: (...args: T) => Promise<R>): (...args: T) => Promise<R> {
     return async (...args: T): Promise<R> => {
@@ -69,6 +91,19 @@ class MiddlewareHandlers {
         throw error;
       }
     };
+  }
+
+  private static async authenticateUserIdentity(c: RequestContext): Promise<string> {
+    const env: AuthenticatedEnv = c.env as AuthenticatedEnv;
+    if ((env.DEMO_MODE || DEFAULT_DEMO_MODE) === 'true') {
+      return DEMO_USER_EMAIL;
+    }
+    const authHeader: string | undefined = c.req.header('Authorization');
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      const token: string = authHeader.substring(7);
+      return await TokenAuthUtil.authenticateWithPAT(token, env.AccessBridgeDB);
+    }
+    return await EmailValidationUtil.getAuthenticatedUserEmail(c.req.raw, env.TEAM_DOMAIN, env.POLICY_AUD);
   }
 }
 

--- a/src/middleware/MiddlewareHandlers.ts
+++ b/src/middleware/MiddlewareHandlers.ts
@@ -1,4 +1,6 @@
+import { AUDIT_ACTIONS } from '@/constants/AuditActions';
 import { INTERNAL_HEADER_PREFIX, SELF_WORKER_BASE_HOSTNAME } from '@/constants';
+import { AuditLogDAO } from '@/dao/AuditLogDAO';
 import { Context, Next } from 'hono';
 import { HMACHandler } from './HMACHandler';
 import { IServiceError } from '@/error';
@@ -13,6 +15,44 @@ class MiddlewareHandlers {
         await this.withErrorTranslation(HMACHandler.validateInternalRequest)(c, next);
       } else {
         await next();
+      }
+    };
+  }
+
+  public static activityAudit() {
+    return async (
+      c: Context<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>,
+      next: Next,
+    ): Promise<void> => {
+      let statusCode: number = 200;
+
+      try {
+        await next();
+        statusCode = c.res.status;
+      } catch (error: unknown) {
+        if (error instanceof Error && 'status' in error && typeof error.status === 'number') {
+          statusCode = error.status;
+        } else {
+          statusCode = 500;
+        }
+        throw error;
+      } finally {
+        try {
+          const method: string = c.req.method;
+          const url: URL = new URL(c.req.url);
+          const path: string = url.pathname;
+          const action: string = AUDIT_ACTIONS[`${method}:${path}`] || `${method}:${path}`;
+          const userEmail: string = c.get('AuthenticatedUserEmailAddress') || 'unknown';
+          const ipAddress: string | undefined = c.req.header('CF-Connecting-IP');
+          const userAgentHeader: string | undefined = c.req.header('User-Agent');
+
+          const auditLogDAO: AuditLogDAO = new AuditLogDAO(c.env.AccessBridgeDB);
+          c.executionCtx.waitUntil(
+            auditLogDAO.create(userEmail, action, method, path, statusCode, undefined, undefined, ipAddress, userAgentHeader),
+          );
+        } catch {
+          console.warn('Failed to write audit log');
+        }
       }
     };
   }

--- a/src/workers/AccessBridgeWorker.ts
+++ b/src/workers/AccessBridgeWorker.ts
@@ -69,6 +69,8 @@ class AccessBridgeWorker extends AbstractWorker {
     app.use('*', MiddlewareHandlers.hmacValidation());
     app.use('/api/*', MiddlewareHandlers.activityAudit());
     app.use('/federate', MiddlewareHandlers.activityAudit());
+    app.use('/api/*', MiddlewareHandlers.authentication());
+    app.use('/federate', MiddlewareHandlers.authentication());
 
     const openapi: HonoOpenAPIRouterType<{
       Bindings: Env;

--- a/src/workers/AccessBridgeWorker.ts
+++ b/src/workers/AccessBridgeWorker.ts
@@ -67,6 +67,8 @@ class AccessBridgeWorker extends AbstractWorker {
 
     // Middleware Handlers
     app.use('*', MiddlewareHandlers.hmacValidation());
+    app.use('/api/*', MiddlewareHandlers.activityAudit());
+    app.use('/federate', MiddlewareHandlers.activityAudit());
 
     const openapi: HonoOpenAPIRouterType<{
       Bindings: Env;

--- a/test/middleware/MiddlewareHandlers.test.ts
+++ b/test/middleware/MiddlewareHandlers.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { DEMO_USER_EMAIL, INTERNAL_USER_EMAIL_HEADER, SELF_WORKER_BASE_HOSTNAME } from '@/constants';
+import { UnauthorizedError } from '@/error';
+import { TokenAuthUtil } from '@/utils/TokenAuthUtil';
 
 const { auditLogCreateSpy, auditLogConstructorSpy, waitUntilSpy } = vi.hoisted(() => {
   return {
@@ -25,8 +28,40 @@ vi.mock('@/dao/AuditLogDAO', () => {
 
 import { MiddlewareHandlers } from '@/middleware';
 
+type TestApp = Hono<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>;
+
+function createExecutionContext(): ExecutionContext {
+  return {
+    waitUntil: waitUntilSpy,
+    passThroughOnException: vi.fn(),
+  } as unknown as ExecutionContext;
+}
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    AccessBridgeDB: { mock: true } as D1DatabaseSession,
+    DEMO_MODE: 'false',
+    TEAM_DOMAIN: 'https://team.example.com',
+    POLICY_AUD: 'policy-aud',
+    ...overrides,
+  } as Env;
+}
+
+function createApp(includeAudit: boolean = false): TestApp {
+  const app = new Hono<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>();
+  if (includeAudit) {
+    app.use('*', MiddlewareHandlers.activityAudit());
+  }
+  app.use('*', MiddlewareHandlers.authentication());
+  app.get('/api/test', async (c) => {
+    return c.json({ email: c.get('AuthenticatedUserEmailAddress') });
+  });
+  return app;
+}
+
 describe('MiddlewareHandlers', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     auditLogCreateSpy.mockReset();
     auditLogCreateSpy.mockResolvedValue(undefined);
     auditLogConstructorSpy.mockReset();
@@ -49,11 +84,8 @@ describe('MiddlewareHandlers', () => {
             'User-Agent': 'Vitest',
           },
         }),
-        { AccessBridgeDB: { mock: true } as D1DatabaseSession } as Env,
-        {
-          waitUntil: waitUntilSpy,
-          passThroughOnException: vi.fn(),
-        } as unknown as ExecutionContext,
+        createEnv(),
+        createExecutionContext(),
       );
 
       expect(response.status).toBe(201);
@@ -89,14 +121,124 @@ describe('MiddlewareHandlers', () => {
 
       const response: Response = await app.fetch(
         new Request('https://worker.example.com/api/test'),
-        { AccessBridgeDB: { mock: true } as D1DatabaseSession } as Env,
-        {
-          waitUntil: waitUntilSpy,
-          passThroughOnException: vi.fn(),
-        } as unknown as ExecutionContext,
+        createEnv(),
+        createExecutionContext(),
       );
 
       expect(response.status).toBe(401);
+      expect(auditLogCreateSpy).toHaveBeenCalledWith(
+        'unknown',
+        'GET:/api/test',
+        'GET',
+        '/api/test',
+        401,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(waitUntilSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('authentication', () => {
+    it('uses the demo user when demo mode is enabled', async () => {
+      const app: TestApp = createApp();
+
+      const response: Response = await app.fetch(new Request('https://worker.example.com/api/test'), createEnv({ DEMO_MODE: 'true' }), createExecutionContext());
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ email: DEMO_USER_EMAIL });
+    });
+
+    it('authenticates bearer tokens via PAT lookup', async () => {
+      const app: TestApp = createApp();
+      const authenticateWithPATSpy = vi.spyOn(TokenAuthUtil, 'authenticateWithPAT').mockResolvedValue('pat@example.com');
+
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test', {
+          headers: {
+            Authorization: 'Bearer test-token',
+          },
+        }),
+        createEnv(),
+        createExecutionContext(),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ email: 'pat@example.com' });
+      expect(authenticateWithPATSpy).toHaveBeenCalledWith('test-token', { mock: true });
+    });
+
+    it('returns a 401 response when PAT authentication fails', async () => {
+      const app: TestApp = createApp();
+      vi.spyOn(TokenAuthUtil, 'authenticateWithPAT').mockRejectedValue(new UnauthorizedError('PAT rejected'));
+
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test', {
+          headers: {
+            Authorization: 'Bearer bad-token',
+          },
+        }),
+        createEnv(),
+        createExecutionContext(),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        Exception: {
+          Type: 'Unauthorized',
+          Message: 'PAT rejected',
+        },
+      });
+    });
+
+    it('authenticates using the Cloudflare Access email header', async () => {
+      const app: TestApp = createApp();
+
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test', {
+          headers: {
+            'Cf-Access-Authenticated-User-Email': 'header@example.com',
+          },
+        }),
+        createEnv(),
+        createExecutionContext(),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ email: 'header@example.com' });
+    });
+
+    it('authenticates internal self-worker requests from the internal user header', async () => {
+      const app: TestApp = createApp();
+
+      const response: Response = await app.fetch(
+        new Request(`https://${SELF_WORKER_BASE_HOSTNAME}/api/test`, {
+          headers: {
+            [INTERNAL_USER_EMAIL_HEADER]: 'internal@example.com',
+          },
+        }),
+        createEnv(),
+        createExecutionContext(),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ email: 'internal@example.com' });
+    });
+
+    it('returns a 401 response and audit log entry when authentication fails before route execution', async () => {
+      const app: TestApp = createApp(true);
+
+      const response: Response = await app.fetch(new Request('https://worker.example.com/api/test'), createEnv(), createExecutionContext());
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({
+        Exception: {
+          Type: 'Unauthorized',
+          Message: 'No authenticated user email or JWT token provided in request headers.',
+        },
+      });
       expect(auditLogCreateSpy).toHaveBeenCalledWith(
         'unknown',
         'GET:/api/test',

--- a/test/middleware/MiddlewareHandlers.test.ts
+++ b/test/middleware/MiddlewareHandlers.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const { auditLogCreateSpy, auditLogConstructorSpy, waitUntilSpy } = vi.hoisted(() => {
+  return {
+    auditLogCreateSpy: vi.fn(),
+    auditLogConstructorSpy: vi.fn(),
+    waitUntilSpy: vi.fn(),
+  };
+});
+
+vi.mock('@/dao/AuditLogDAO', () => {
+  class MockAuditLogDAO {
+    constructor(database: unknown) {
+      auditLogConstructorSpy(database);
+    }
+
+    create = auditLogCreateSpy;
+  }
+
+  return {
+    AuditLogDAO: MockAuditLogDAO,
+  };
+});
+
+import { MiddlewareHandlers } from '@/middleware';
+
+describe('MiddlewareHandlers', () => {
+  beforeEach(() => {
+    auditLogCreateSpy.mockReset();
+    auditLogCreateSpy.mockResolvedValue(undefined);
+    auditLogConstructorSpy.mockReset();
+    waitUntilSpy.mockReset();
+  });
+
+  describe('activityAudit', () => {
+    it('writes an audit log entry with the authenticated user and response status', async () => {
+      const app = new Hono<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>();
+      app.use('*', MiddlewareHandlers.activityAudit());
+      app.get('/api/test', async (c) => {
+        c.set('AuthenticatedUserEmailAddress', 'user@example.com');
+        return c.json({ ok: true }, 201);
+      });
+
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test', {
+          headers: {
+            'CF-Connecting-IP': '203.0.113.10',
+            'User-Agent': 'Vitest',
+          },
+        }),
+        { AccessBridgeDB: { mock: true } as D1DatabaseSession } as Env,
+        {
+          waitUntil: waitUntilSpy,
+          passThroughOnException: vi.fn(),
+        } as unknown as ExecutionContext,
+      );
+
+      expect(response.status).toBe(201);
+      expect(auditLogConstructorSpy).toHaveBeenCalledWith({ mock: true });
+      expect(auditLogCreateSpy).toHaveBeenCalledWith(
+        'user@example.com',
+        'GET:/api/test',
+        'GET',
+        '/api/test',
+        201,
+        undefined,
+        undefined,
+        '203.0.113.10',
+        'Vitest',
+      );
+      expect(waitUntilSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes an audit log entry with unknown user when authentication has not populated the context', async () => {
+      const app = new Hono<{ Bindings: Env; Variables: { AuthenticatedUserEmailAddress: string } }>();
+      app.use('*', MiddlewareHandlers.activityAudit());
+      app.get('/api/test', async (c) => {
+        return c.json(
+          {
+            Exception: {
+              Type: 'Unauthorized',
+              Message: 'Missing auth',
+            },
+          },
+          401,
+        );
+      });
+
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test'),
+        { AccessBridgeDB: { mock: true } as D1DatabaseSession } as Env,
+        {
+          waitUntil: waitUntilSpy,
+          passThroughOnException: vi.fn(),
+        } as unknown as ExecutionContext,
+      );
+
+      expect(response.status).toBe(401);
+      expect(auditLogCreateSpy).toHaveBeenCalledWith(
+        'unknown',
+        'GET:/api/test',
+        'GET',
+        '/api/test',
+        401,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(waitUntilSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/middleware/MiddlewareHandlers.test.ts
+++ b/test/middleware/MiddlewareHandlers.test.ts
@@ -119,11 +119,7 @@ describe('MiddlewareHandlers', () => {
         );
       });
 
-      const response: Response = await app.fetch(
-        new Request('https://worker.example.com/api/test'),
-        createEnv(),
-        createExecutionContext(),
-      );
+      const response: Response = await app.fetch(new Request('https://worker.example.com/api/test'), createEnv(), createExecutionContext());
 
       expect(response.status).toBe(401);
       expect(auditLogCreateSpy).toHaveBeenCalledWith(
@@ -145,7 +141,11 @@ describe('MiddlewareHandlers', () => {
     it('uses the demo user when demo mode is enabled', async () => {
       const app: TestApp = createApp();
 
-      const response: Response = await app.fetch(new Request('https://worker.example.com/api/test'), createEnv({ DEMO_MODE: 'true' }), createExecutionContext());
+      const response: Response = await app.fetch(
+        new Request('https://worker.example.com/api/test'),
+        createEnv({ DEMO_MODE: 'true' }),
+        createExecutionContext(),
+      );
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toEqual({ email: DEMO_USER_EMAIL });


### PR DESCRIPTION
## Summary

This PR moves two cross-cutting request concerns out of IActivityAPIRoute and into Hono middleware:

1. Activity audit logging
2. Request authentication

The refactor was split into separate commits so audit and auth changes can be reviewed and reverted
independently if needed.

## What Changed

- Added activity audit middleware and applied it to protected routes:
    - /api/*
    - /federate
- Added authentication middleware and applied it to the same protected routes
- Removed audit logging from IActivityAPIRoute
- Removed user identity resolution from IActivityAPIRoute
- Kept the existing request context contract:
    - AuthenticatedUserEmailAddress
- Kept admin authorization behavior in IAdminActivityAPIRoute
- Added middleware coverage for:
    - audit logging
    - demo mode auth
    - PAT auth success/failure
    - Cloudflare Access header auth
    - internal self-worker auth
    - auth-failure audit behavior

## Behavior Notes

- Protected routes still require authentication
- /federate remains protected
- /docs, OpenAPI docs, and SPA routes remain public
- Failed auth requests are still audited
- Admin superadmin/demo-mode enforcement is unchanged

## Verification

- npm test -- --run test/middleware/MiddlewareHandlers.test.ts test/middleware/HMACHandler.test.ts test/
utils/EmailValidationUtil.test.ts test/utils/ErrorTranslationUtil.test.ts
- node --max-old-space-size=2048 ./node_modules/typescript/bin/tsc --noEmit
- node --max-old-space-size=2048 ./node_modules/typescript/bin/tsc --noEmit --project tsconfig.backend.json
- npm run prettier
- npm run lint

## Commit Breakdown

- REFACTOR: move activity audit logging to middleware
- REFACTOR: move request authentication to middleware
- CHORE: run prettier and fix lint issues

