### PR TITLE
Add Retry Logic to Auto-Merge Step

### DIFF
--- a/.github/actions/retry-step/action.yml
+++ b/.github/actions/retry-step/action.yml
@@ -1,0 +1,39 @@
+name: Retry Step
+description: Retry a bash command on failure
+
+inputs:
+  command:
+    description: The bash command to run
+    required: true
+  max_attempts:
+    description: Maximum number of attempts
+    required: false
+    default: '3'
+  delay:
+    description: Seconds to wait between attempts
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        attempt=0
+        max=${{ inputs.max_attempts }}
+        delay=${{ inputs.delay }}
+        while true; do
+          attempt=$(( attempt + 1 ))
+          printf '::notice title=Retry Step::Attempt %d of %d\n' "$attempt" "$max"
+          if eval "$RETRY_COMMAND"; then
+            exit 0
+          fi
+          if [ "$attempt" -ge "$max" ]; then
+            printf '::error title=Retry Step::Command failed after %d attempts\n' "$max"
+            exit 1
+          fi
+          printf '::warning title=Retry Step::Command failed, retrying in %ds...\n' "$delay"
+          sleep "$delay"
+        done
+      env:
+        RETRY_COMMAND: ${{ inputs.command }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,8 +79,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Enable Auto-Merge
-        run: gh pr merge --auto --merge "$PR_URL"
+        uses: ./.github/actions/retry-step
+        with:
+          command: gh pr merge --auto --merge "$PR_URL"
+          max_attempts: '5'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Create retry-step composite action and wrap the Enable Auto-Merge step with max_attempts=5 to improve reliability against transient GitHub API failures. Adds Checkout Repository step required for local action resolution.