### PR TITLE
Add Retry Logic to All Workflow Steps

### DIFF
--- a/.github/workflows/azure-devops-backup.yml
+++ b/.github/workflows/azure-devops-backup.yml
@@ -38,9 +38,11 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh/id_rsa
 
-      - name: Add SSH Remote and Push main Branch
-        env:
-          REMOTE_REPO_URL: ${{ secrets.BACKUP_REPO_AZURE_DEVOPS_REPO_URL }}
-        run: |
-          git remote add backup "${REMOTE_REPO_URL}"
-          git push --force backup main:main
+      - name: Add SSH Remote
+        run: git remote add backup "${{ secrets.BACKUP_REPO_AZURE_DEVOPS_REPO_URL }}"
+
+      - name: Push main Branch to Azure DevOps
+        uses: ./.github/actions/retry-step
+        with:
+          command: git push --force backup main:main
+          max_attempts: '3'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -42,10 +42,16 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Prepare Wrangler Configuration
-        run: pnpm exec tsx scripts/prepare-wrangler-config.ts
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec tsx scripts/prepare-wrangler-config.ts
+          max_attempts: '3'
         env:
           WRANGLER_JSONC: ${{ vars.WRANGLER_JSONC }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -62,13 +68,19 @@ jobs:
           fi
 
       - name: Initialize Cloudflare Secrets Store
-        run: pnpm exec tsx scripts/init-secrets.ts
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec tsx scripts/init-secrets.ts
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Apply Database Migration
-        run: pnpm exec wrangler d1 migrations apply --remote AccessBridgeDB
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec wrangler d1 migrations apply --remote AccessBridgeDB
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -92,7 +104,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy with Wrangler
-        run: pnpm exec wrangler deploy
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec wrangler deploy
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -118,7 +133,10 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Build Frontend
         run: pnpm --filter @aws-access-bridge/web build
@@ -134,12 +152,15 @@ jobs:
           CLOUDFLARE_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
 
       - name: Deploy with Wrangler Pages
-        run: |
-          pnpm exec wrangler pages deploy \
-            --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" \
-            --branch "${DEPLOY_BRANCH}" \
-            --commit-hash "${DEPLOY_SHA}" \
+        uses: ./.github/actions/retry-step
+        with:
+          command: >
+            pnpm exec wrangler pages deploy
+            --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}"
+            --branch "${DEPLOY_BRANCH}"
+            --commit-hash "${DEPLOY_SHA}"
             --commit-message "$(git log -1 --pretty=%s)"
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,10 +36,16 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Run Tests and Checks
-        run: pnpm run checks
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm run checks
+          max_attempts: '2'
 
   build:
     name: Build
@@ -59,7 +65,10 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Build Web App
         run: pnpm --filter @aws-access-bridge/web build
@@ -102,16 +111,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Dispatch Deployment
-        uses: actions/github-script@v7
+        uses: ./.github/actions/retry-step
         with:
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'Upstream Sync Deployment',
-              client_payload: {
-                branch: context.payload.client_payload?.branch || 'main',
-                sha: context.payload.client_payload?.sha || context.sha,
-              },
-            });
+          command: >
+            printf '{"event_type":"Upstream Sync Deployment","client_payload":{"branch":"%s","sha":"%s"}}\n'
+            "$PAYLOAD_BRANCH" "$PAYLOAD_SHA"
+            | gh api repos/${{ github.repository }}/dispatches --method POST --input -
+          max_attempts: '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD_BRANCH: ${{ github.event.client_payload.branch || 'main' }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha || github.sha }}

--- a/.github/workflows/scheduled-version-update.yml
+++ b/.github/workflows/scheduled-version-update.yml
@@ -35,4 +35,10 @@ jobs:
           fi
 
           git commit -m "CHORE: version update"
-          git push
+
+          for i in {1..3}; do
+            if git push; then
+              break
+            fi
+            if [ $i -lt 3 ]; then sleep 10; else exit 1; fi
+          done

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -30,11 +30,9 @@ jobs:
 
       - name: Trigger CI for synced commits
         if: steps.sync.outputs.has_new_commits == 'true'
-        uses: actions/github-script@v7
+        uses: ./.github/actions/retry-step
         with:
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'Upstream Sync',
-            });
+          command: gh api repos/${{ github.repository }}/dispatches --method POST -f event_type='Upstream Sync'
+          max_attempts: '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Align retry patterns with Mail-Otter across all 5 workflow files:

- continuous-integration.yml: Install Dependencies (max_attempts=3), Run Tests and Checks (max_attempts=2), dispatch via gh api (2)
- continuous-deployment.yml: Install Dependencies, Prepare Wrangler Config, Initialize Secrets, Apply Migration, Deploy Worker, Install Dependencies (pages), Deploy Pages (all max_attempts=3)
- upstream-sync.yml: Trigger CI via gh api (max_attempts=2)
- scheduled-version-update.yml: git push inline retry loop (3)
- azure-devops-backup.yml: Split remote add from push, retry push (max_attempts=3)