### PR TITLE
Include User Routes In Pages Function Routing

### DIFF
--- a/apps/web/public/_routes.json
+++ b/apps/web/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/api/*", "/federate", "/docs", "/docs/*", "/openapi.json", "/openapi.yaml"],
+  "include": ["/api/*", "/user/*", "/docs", "/docs/*", "/openapi.json", "/openapi.yaml"],
   "exclude": ["/assets/*"]
 }


### PR DESCRIPTION
Pages Functions only intercept paths listed in public/_routes.json. After the user/api split, /user/* was missing, so authenticated /user/* requests were served static index.html instead of reaching the API Worker via functions/[[path]].ts. Also drops the removed /federate alias.