### PR TITLE
Add Zero Trust Login Button

### DIFF
--- a/apps/web/src/components/Unauthorized.tsx
+++ b/apps/web/src/components/Unauthorized.tsx
@@ -1,17 +1,26 @@
 'use client';
 
+import { ZERO_TRUST_AUTHENTICATION_PATH } from '../lib/constants';
+
+function authenticateWithZeroTrust(): void {
+  globalThis.location.assign(ZERO_TRUST_AUTHENTICATION_PATH);
+}
+
 export default function Unauthorized() {
   return (
     <div className="bg-gray-900 min-h-screen text-white flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-6xl font-bold text-red-400 mb-4">401</h1>
-        <h2 className="text-2xl font-semibold mb-4">Unauthorized</h2>
-        <p className="text-gray-400 mb-8">You are not authorized to access this application. Please log in to continue.</p>
+      <div className="text-center px-6">
+        <div className="text-3xl font-semibold mb-1 tracking-tight">
+          <span className="text-blue-400">AWS</span> AccessBridge
+        </div>
+        <h1 className="text-lg font-medium mt-4 mb-1">Authentication Required</h1>
+        <p className="text-gray-400 text-sm">Please authenticate with Cloudflare Zero Trust to access this application.</p>
         <button
-          onClick={() => window.location.reload()}
-          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded transition-colors"
+          type="button"
+          onClick={authenticateWithZeroTrust}
+          className="mt-6 bg-blue-600 hover:bg-blue-700 text-white px-6 py-2.5 rounded text-sm font-medium transition-colors"
         >
-          Try Again
+          Authenticate with Cloudflare Zero Trust
         </button>
       </div>
     </div>

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,0 +1,6 @@
+'use client';
+
+// Path that is always protected by Cloudflare Access. Navigating here triggers
+// the Zero Trust login flow when the user has no valid session; after login,
+// Access redirects back to the application home.
+export const ZERO_TRUST_AUTHENTICATION_PATH = '/';


### PR DESCRIPTION
Mirror Mail-Otter: the unauthorized screen now navigates to an Access-protected path (ZERO_TRUST_AUTHENTICATION_PATH) so Cloudflare Access drives the login flow and redirects back home. Replaces the ineffective reload-only Try Again button.